### PR TITLE
Various audio_download fixes

### DIFF
--- a/audio-download.py
+++ b/audio-download.py
@@ -101,9 +101,9 @@ def download_name(r):
     dt = parsedate(r["recordingDateTime"])
     device_name = r["Device"]["devicename"]
 
-    mime_type = r.get("fileMimeType")
+    mime_type = r.get("rawMimeType")
     if not mime_type:
-        raise ValueError("recording has no mime type")
+        raise ValueError("recording has no raw mime type")
     ext = "." + MIME_TO_EXT[mime_type]
 
     return device_name + "-" + dt.strftime("%Y%m%d-%H%M%S") + ext

--- a/audio-download.py
+++ b/audio-download.py
@@ -113,7 +113,7 @@ def download_name(r, local_time):
         dt = dt.astimezone(local_tz)
     device_name = r["Device"]["devicename"]
 
-    mime_type = r.get("rawMimeType", "audio/mp4")
+    mime_type = r.get("rawMimeType")
     if not mime_type:
         raise ValueError("recording has no raw mime type")
     ext = MIME_TO_EXT[mime_type]

--- a/audio-download.py
+++ b/audio-download.py
@@ -17,6 +17,8 @@ MIME_TO_EXT = {
     "audio/mpeg": "mp3",
 }
 
+local_tz = tzlocal()
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -104,7 +106,6 @@ def download(q, api, args):
         finally:
             q.task_done()
 
-local_tz = tzlocal()
 
 def download_name(r, local_time):
     dt = parsedate(r["recordingDateTime"])
@@ -112,12 +113,12 @@ def download_name(r, local_time):
         dt = dt.astimezone(local_tz)
     device_name = r["Device"]["devicename"]
 
-    mime_type = r.get("rawMimeType")
+    mime_type = r.get("rawMimeType", "audio/mp4")
     if not mime_type:
         raise ValueError("recording has no raw mime type")
-    ext = "." + MIME_TO_EXT[mime_type]
+    ext = MIME_TO_EXT[mime_type]
 
-    return device_name + "-" + dt.strftime("%Y%m%d-%H%M%S") + ext
+    return f"{r['id']}-{device_name}-{dt.strftime('%Y%m%d-%H%M%S')}.{ext}"
 
 
 def iter_to_file(source, filename):


### PR DESCRIPTION
- Use correct MIME type field: This script downloads the original, raw file so it should be
consulting the raw MIME type to determine the file extension.
-  Allow timestamps in filename to optionally be in local time (instead of UTC)
- Include recording id in output filename: this is really useful when comparing recording files from different sources.