### PR TITLE
Adjust cptv-upload to account for recent API changes

### DIFF
--- a/api.py
+++ b/api.py
@@ -97,10 +97,10 @@ class API(APIBase):
         r.raise_for_status()
         yield from r.iter_content(chunk_size=4096)
 
-    def upload_recording(self, devicename, filename, props=None):
+    def upload_recording(self, groupname, devicename, filename, props=None):
         """Upload a recording on behalf of a device.
         """
-        url = urljoin(self._baseurl, "/api/v1/recordings/" + devicename)
+        url = urljoin(self._baseurl, "/api/v1/recordings/device/{}/group/{}".format(devicename, groupname))
 
         if not props:
             if filename.endswith(".cptv"):

--- a/cptv-upload.py
+++ b/cptv-upload.py
@@ -10,12 +10,13 @@ def main():
     )
     parser.add_argument("username", help="Username to upload as")
     parser.add_argument("password", help="Password to authenticate with")
+    parser.add_argument("groupname", help="Group name to upload on behalf of")
     parser.add_argument("devicename", help="Device to upload on behalf of")
     parser.add_argument("filename", help="File to upload")
     args = parser.parse_args()
 
     api = API(args.server_url, args.username, args.password)
-    api.upload_recording(args.devicename, args.filename)
+    api.upload_recording(args.groupname, args.devicename, args.filename)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Uploading on behalf of a device from a user account now requires the group name too.